### PR TITLE
Make cipher checking case-insensitive

### DIFF
--- a/core/components/filelister/model/filelister/filelister.class.php
+++ b/core/components/filelister/model/filelister/filelister.class.php
@@ -180,13 +180,17 @@ class FileLister {
         $key = md5($key); /* to improve variance */
 
         $cipher = "DES-CFB";
-        if (in_array($cipher, openssl_get_cipher_methods()))
-        {
+        $available = openssl_get_cipher_methods();
+        $available = array_map('strtoupper', $available);
+        if (in_array($cipher, $available)) {
             $ivlen = openssl_cipher_iv_length($cipher);
             $iv = openssl_random_pseudo_bytes($ivlen);
             $ciphertext = openssl_encrypt($str, $cipher, $key, 0, $iv);
             $ciphertext = $iv . $ciphertext;
             return urlencode($ciphertext);
+        }
+        else {
+            $this->modx->log(modX::LOG_LEVEL_ERROR, "Cipher {$cipher} is not available on the server, FileLister cannot encrypt string.");
         }
     }
 
@@ -204,12 +208,16 @@ class FileLister {
         $key = md5($key);
 
         $cipher = "DES-CFB";
-        if (in_array($cipher, openssl_get_cipher_methods()))
-        {
+        $available = openssl_get_cipher_methods();
+        $available = array_map('strtoupper', $available);
+        if (in_array($cipher, $available)) {
             $ivlen = openssl_cipher_iv_length($cipher);
             $iv = substr($str,0,$ivlen);
             $str = substr($str,$ivlen);
             return openssl_decrypt($str, $cipher, $key, 0, $iv);
+        }
+        else {
+            $this->modx->log(modX::LOG_LEVEL_ERROR, "Cipher {$cipher} is not available on the server, FileLister cannot decrypt string.");
         }
     }
 


### PR DESCRIPTION
Working for a client, they experienced an issue where the cipher methods were all returned in lowercase while the requested $cipher is specified in uppercase. By uppercasing them all, FileLister works again, and threw in an extra log message for bonus points.